### PR TITLE
Add LINE Engineers' Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@
 * [Java World](http://www.javaworld.com/) - Java
 * [jGuru](http://www.jguru.com/) - Java
 * [Javarevisited](http://javarevisited.blogspot.sg/) - Java
+* [LINE](http://developers.linecorp.com/blog/)
 * [MySQL](http://dev.mysql.com/)
 * [Netflix Tech Blog](http://techblog.netflix.com/)
 * [New Relic](https://blog.newrelic.com/)


### PR DESCRIPTION
I added English version of LINE Engineers' Blog; http://developers.linecorp.com/blog/

fyi; also available in Japanese and Korean:
* ja: http://developers.linecorp.com/blog/ja/
* ko: http://developers.linecorp.com/blog/ko/