### PR TITLE
hyeon.me supports HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 * [김종인](http://zzong.net) - Java, Spring
 * [김준철](http://jetalog.net/) - Solr
 * [김지영](https://brunch.co.kr/@pubjinson)
-* [김지현](http://hyeon.me/)
+* [김지현](https://hyeon.me/)
 * [김진국](http://forensic-proof.com/) - 포렌식
 * [김진수](https://item4.github.io/) - Web
 * [김진욱](http://rein.kr/blog/)


### PR DESCRIPTION
You should use TLS connection whenever possible. HTTP hyperlink may risk you SSL stripping attack.

###### Reference
- https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https