### PR TITLE
김헌진 블로그 추가

### DIFF
--- a/Korea-Dev-RSS.opml
+++ b/Korea-Dev-RSS.opml
@@ -168,6 +168,7 @@
       <outline title="김포프" xmlUrl="http://feeds.feedburner.com/kblog-blindrenderer?format=xml"></outline>
       <outline title="김한결" xmlUrl="http://devkyeol.tistory.com/rss"></outline>
       <outline title="김한솔" xmlUrl="https://medium.com/feed/@zvuc"></outline>
+      <outline title="김헌진" xmlUrl="http://flymogi.tistory.com/rss"></outline>
       <outline title="김현유(미키김)" xmlUrl="http://www.mickeykim.com/rss"></outline>
       <outline title="김형준" xmlUrl="http://www.gisdeveloper.co.kr/?feed=rss2"></outline>
       <outline title="김형준" xmlUrl="http://www.jaso.co.kr/index.php/feed/"></outline>

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Tag Cloud
 | 김포프 | http://kblog.popekim.com/ |  | [![](icons/rss-icon.png)](http://feeds.feedburner.com/kblog-blindrenderer?format=xml)[![](icons/google-plus-icon.png)](https://plus.google.com/+%EA%B9%80%ED%8F%AC%ED%94%84)[![](icons/facebook-icon.png)](https://www.facebook.com/profile.php?id=100001300259016)[![](icons/twitter-icon.png)](https://twitter.com/blindrendererkr) |
 | 김한결 | http://devkyeol.tistory.com/ |  | [![](icons/rss-icon.png)](http://devkyeol.tistory.com/rss) |
 | 김한솔 | https://medium.com/@zvuc |  | [![](icons/rss-icon.png)](https://medium.com/feed/@zvuc)[![](icons/twitter-icon.png)](https://twitter.com/zvuuc) |
+| 김헌진 | http://flymogi.tistory.com/ | Android | [![](icons/rss-icon.png)](http://flymogi.tistory.com/rss)[![](icons/github-icon.png)](https://github.com/KimHunJin) |
 | 김현남 | http://booksummary.tistory.com/ |  |  |
 | 김한웅 | https://hanwong.github.io/ | Front-end | [![](icons/facebook-icon.png)](https://www.facebook.com/hanwong85)[![](icons/twitter-icon.png)](https://twitter.com/HanW000ng)[![](icons/github-icon.png)](https://github.com/hanwong) |
 | 김현유(미키김) | http://www.mickeykim.com/ | 구글 | [![](icons/rss-icon.png)](http://www.mickeykim.com/rss)[![](icons/facebook-icon.png)](https://www.facebook.com/mickeyk)[![](icons/twitter-icon.png)](https://twitter.com/mickeyk) |

--- a/db.yml
+++ b/db.yml
@@ -1130,9 +1130,6 @@
   facebook: https://www.facebook.com/hanwong85
   twitter: https://twitter.com/HanW000ng
   instagram: https://www.instagram.com/hanationbear/
-- name: 김현남
-  blog: http://booksummary.tistory.com/
-  description: ''
 - name: 김헌기
   blog: https://hunlabs.wordpress.com/
   rss: https://hunlabs.wordpress.com/feed/
@@ -1140,6 +1137,14 @@
   facebook: https://www.facebook.com/hnki0104
   linkedin: https://www.linkedin.com/in/darion-kim-9a8b2aa6
   slideshare: https://www.slideshare.net/hnki0104
+- name: 김헌진
+  blog: http://flymogi.tistory.com/
+  rss: http://flymogi.tistory.com/rss
+  github: https://github.com/KimHunJin
+  description: Android  
+- name: 김현남
+  blog: http://booksummary.tistory.com/
+  description: ''
 - name: 김현유(미키김)
   blog: http://www.mickeykim.com/
   rss: http://www.mickeykim.com/rss


### PR DESCRIPTION
readme, db, korea dev 김헌진 추가
db 잘못된 이름 순서 수정
(김현남 -> 김헌기 -> 김헌진) --> (김헌기 -> 김헌진 -> 김현남)

김헌진 블로그 새로 추가했습니다~
추가로 db에 이름 순서가 잘못 되어 있어 변경했습니다.