### PR TITLE
김호영 블로그 도메인 및 Github 주소 변경

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -1827,10 +1827,10 @@
   description: nimf
   github: https://github.com/cogniti
 - name: 김호영
-  blog: https://khzero.github.io/
-  rss: https://khzero.github.io/feed
-  description: Spring Boot, Javascript
-  github: https://github.com/khzero
+  blog: https://blog.hodory.dev/
+  rss: https://blog.hodory.dev/feed
+  description: PHP, Spring Boot, Javascript
+  github: https://github.com/hodory
 - name: 김홍배
   slideshare: https://www.slideshare.net/ssuser06e0c5
 - name: 김화수


### PR DESCRIPTION
안녕하세요

깃허브 닉네임을 변경하면서 도메인도 `.dev`로 변경되어, db.yml 수정하였습니다.

현재 기존 도메인의 포스팅은 메타로 리디렉션 걸어두었습니다.

감사합니다.