### PR TITLE
Samslow blog URL update

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -3436,8 +3436,8 @@
   description: 디자인
   home: http://zalhan.kr
 - name: 서현석
-  blog: https://samslow.me/
-  rss: https://samslow.me/feed.xml
+  blog: https://samslow.github.io/
+  rss: https://samslow.github.io/feed.xml
   description: Web
   facebook: https://www.facebook.com/samsloww
   youtube: https://www.youtube.com/channel/UCI9iq2DoD55i40OWltsPGyQ


### PR DESCRIPTION
기존 samslow.me가 도메인 만료로 samslow.github.io로 변경되었습니다.