### PR TITLE
노찬우 정보 수정

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -2308,12 +2308,11 @@
   instagram: https://www.instagram.com/ttongfly/
   linkedin: https://www.linkedin.com/in/jaewoong-roh-588b3646/
 - name: 노찬우
-  blog: https://rajephon.github.io/blog/
-  rss: https://rajephon.github.io/blog/feed.xml
-  description: Erlang, iOS
+  blog: https://blog.rajephon.dev/
+  rss: https://blog.rajephon.dev/feed.xml
+  description: Erlang, 백엔드, iOS
   github: https://github.com/rajephon
   linkedin: https://www.linkedin.com/in/chanwoo-noh-799b79141/
-  instagram: https://www.instagram.com/rajephon/
   stackoverflow: https://stackoverflow.com/users/5286905/rajephon
 - name: 노찬현
   blog: https://amati.io/


### PR DESCRIPTION
블로그 및 RSS 링크가 변경 전 도메인이 등록되어있어 PR 올립니다.

instagram은 주소가 깨졌고, 개인 용도로만 사용하여 제거합니다.