### PR TITLE
popl blog 주소 변경

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -9117,6 +9117,6 @@
   description: DB
   facebook: https://www.facebook.com/ricky.han.52438
 - name: poplcode
-  blog: https://popl.ml/minilog.html
-  rss: https://popl.ml/minilog.rss
+  blog: https://blog.popl.ml
+  rss: https://blog.popl.ml/rss
   description: php library


### PR DESCRIPTION
popl blog 주소가 변경되었어요.
원래는 gitbook 에 미니로그처럼 쓰려고 했는데, 생각해보니 이건 아닌 것 같아서 티스토리쪽으로 이전 중입니다.
여러번 pull request 번거롭게 해서 죄송해요.